### PR TITLE
Fix for Nvim Warning

### DIFF
--- a/plugin/main.vim
+++ b/plugin/main.vim
@@ -2,7 +2,7 @@ function! PathfinderBegin()
   let b:pf_start = winsaveview()
   echom 'Move to target location and then :PathfinderRun'
 endfunction
-command PathfinderBegin call PathfinderBegin()
+command! PathfinderBegin call PathfinderBegin()
 
 
 function! CreateNode(view, rb, rf)
@@ -128,4 +128,4 @@ function! PathfinderRun()
     echom 'No path found'
   endif
 endfunction
-command PathfinderRun call PathfinderRun()
+command! PathfinderRun call PathfinderRun()


### PR DESCRIPTION
When using with Neovim, there is an "E174: Command already exists: add ! to replace it" error when sourcing vimrc/plug update etc. This doesn't actually affect the plugin functionality, but this small fix removes the warning without any issues.