### PR TITLE
fix neovim for v1.01

### DIFF
--- a/python/output.py
+++ b/python/output.py
@@ -37,7 +37,9 @@ def explained_motions(motions):
 
 
 def output(motions):
-    if vim.eval("has('popupwin')"):
+    if vim.eval("has('nvim')"):
+        print(compact_motions(motions))
+    elif vim.eval("has('popupwin')"):
         output = list(explained_motions(motions))
         vim.Function("popup_create")(
             output,


### PR DESCRIPTION
This should fix it again, the result of the `else` part of the code I changed is the same as the `if` part this however seems to be needed as `nvim` gives an error for `vim.Function` even though it shouldn't be triggered given that nvim returns `0` for `:echo has('popupwin')`. 

On another note, I think the latest change is quite a bit of a regression if not coupled with the ability to configure whether you want pathfinder to run all the time. I find it hard to figure out which motion I've actually done and which keys I could've better used. Usability was a lot better when you could manually run `:PathfinderBegin` and `:PathfinderRun` after which you returned to the previous location and could directly execute the most efficient keys as practice.