### PR TITLE
Limit search area to around the start and target

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,26 @@ Time in seconds where no keypresses occur before starting pathfinding. Note
 that it also starts on other events such as entering insert mode. Set to a
 negative value to use manual commands. *Default: 2*
 
+#### `g:pf_explore_scale`
+Multiplier which determines how many lines the plugin is allowed to explore
+above and below the area between the start and target positions. (The result
+is rounded down.) *Default: 0.5*
+
+This improves performance significantly by preventing the pathfinding algorithm
+from searching in the wrong direction, but some shorter paths may be missed.
+These are mainly suggestions which would not be easy to notice without help
+from a machine, however, so are not as important for training purposes.
+
+Settings below 1 also mean that movements within a line will only use motions
+inside that line.
+
+If you have a powerful computer, you can disable this by setting it to a
+negative value, or increase it to a high value allow exploring more of the file.
+
+#### `g:pf_max_explore`
+Cap the number of surrounding lines explored (see above) to a maximum value.
+As usual, this can be disabled by making it negative. *Default: 10*
+
 #### `g:pf_server_communication_file`
 Internal variable set automatically when launching the server Vim.
 **Do not set this manually, it will break everything.**

--- a/plugin/defaults.vim
+++ b/plugin/defaults.vim
@@ -2,6 +2,13 @@ if !exists('g:pf_autorun_delay')
   let g:pf_autorun_delay = 2
 endif
 
+if !exists('g:pf_explore_scale')
+  let g:pf_explore_scale = 0.5
+endif
+if !exists('g:pf_max_explore')
+  let g:pf_max_explore = 10
+endif
+
 if !exists('g:pf_motions')
   let g:pf_motions = [
     \ {'motion': 'h', 'weight': 1, 'description': 'Left {count} columns'},

--- a/python/client.py
+++ b/python/client.py
@@ -122,6 +122,8 @@ class Client:
             {
                 "start": start_view,
                 "target": target_view,
+                "explore_scale": vim.eval("g:pf_explore_scale"),
+                "max_explore": vim.eval("g:pf_max_explore"),
                 # Using vim.vars would return a vim.list object which we cannot send
                 # because it can't be pickled
                 "motions": vim.eval("g:pf_motions"),

--- a/python/client.py
+++ b/python/client.py
@@ -5,6 +5,8 @@ from multiprocessing import connection
 
 import vim
 
+from explore_lines import get_line_limits
+
 
 class Client:
     """
@@ -118,12 +120,14 @@ class Client:
             of motions as a parameter.
         """
         self.callback = callback
+
+        min_line, max_line = get_line_limits(start_view, target_view)
         self.server_connection.send(
             {
                 "start": start_view,
                 "target": target_view,
-                "explore_scale": vim.eval("g:pf_explore_scale"),
-                "max_explore": vim.eval("g:pf_max_explore"),
+                "min_line": min_line,
+                "max_line": max_line,
                 # Using vim.vars would return a vim.list object which we cannot send
                 # because it can't be pickled
                 "motions": vim.eval("g:pf_motions"),

--- a/python/explore_lines.py
+++ b/python/explore_lines.py
@@ -1,0 +1,46 @@
+import vim
+
+
+def get_explore_lines(search_area_lines):
+    """
+    :param search_area_lines: Number of lines between, and including, the start and
+        target positions.
+    :returns: Number of lines to explore either side of the search area.
+    """
+    # Get setting values from Vim variables
+    explore_scale = int(vim.vars["pf_explore_scale"])
+    max_explore = int(vim.vars["pf_max_explore"])
+
+    if explore_scale < 0:
+        # This filtering is disabled, explore the entire buffer
+        return len(vim.current.buffer)
+
+    # Number of lines to explore above and below the search area is scaled based
+    # on the length of the area. This setting defaults to 0.5, if the search area
+    # was e.g. 6 lines then 3 more lines would be explored on either side.
+    explore_lines = search_area_lines * explore_scale
+    if max_explore >= 0:
+        # Limit to no more than max_explore lines
+        return min(max_explore, explore_lines)
+    else:
+        # Do not limit
+        return explore_lines
+
+
+def get_line_limits(start_view, target_view):
+    """
+    Return the minimum and maximum line numbers to explore.
+
+    :param start_view: The start position.
+    :param target_view: The target position.
+    :returns: Tuple of (min line, max line)
+    """
+    min_line = min(int(start_view["lnum"]), int(target_view["lnum"]))
+    max_line = max(int(start_view["lnum"]), int(target_view["lnum"]))
+    explore_lines = get_explore_lines(max_line - min_line)
+
+    return (
+        max(1, min_line - explore_lines),
+        min(len(vim.current.buffer), max_line + explore_lines)
+    )
+

--- a/python/node.py
+++ b/python/node.py
@@ -38,6 +38,23 @@ class StartNode:
             # The cursor has moved, return the newly created node
             return Node(new_view, self, motion)
 
+    def child_nodes(self, motions, min_line, max_line):
+        """
+        Generator which yields each found child node.
+
+        :param motions: List of motions to test.
+        :param min_line: Child nodes before this line number will not be ignored.
+        :param max_line: Child nodes after this line number will be ignored.
+        """
+        for motion in motions:
+            child_node = self.test_motion(motion)
+            if (
+                child_node is not None and
+                int(child_node.view["lnum"]) >= min_line and
+                int(child_node.view["lnum"]) <= max_line
+            ):
+                yield child_node
+
     def __eq__(self, other):
         return self.g == other.g
 

--- a/python/pathfinder.py
+++ b/python/pathfinder.py
@@ -44,13 +44,15 @@ class Path:
             # Maintain heap invariant after this change
             heapq.heapify(self.open_nodes)
 
-    def find_path(self, client_connection):
+    def find_path(self, client_connection, min_line, max_line):
         """
         Use Dijkstra's algorithm to find the optimal sequence of motions.
 
         :param client_connection: If another pathfinding request is waiting on this
             connection, exit (returning None) as soon as possible. This cancels the
             pathfinding, moving on to the new request immediately.
+        :param min_line: Do not explore above this line number.
+        :param max_line: Do not explore below this line number.
         """
         # Dictionary of all nodes (both open and closed) indexed by the line and column
         self.nodes = {}
@@ -67,12 +69,9 @@ class Path:
                 return current_node.get_refined_path()
 
             # Loop through child nodes of the current node
-            # This is done by looping through the configured motions and testing each one
-            for motion in self.available_motions:
-                child_node = current_node.test_motion(motion)
-                if child_node is None:
-                    continue
-
+            for child_node in current_node.child_nodes(
+                self.available_motions, min_line, max_line
+            ):
                 if child_node.key() in self.nodes:
                     preexisting_child_node = self.nodes[child_node.key()]
                     self._update_preexisting_node(child_node, preexisting_child_node)


### PR DESCRIPTION
Disallow the exploration of nodes outside the search area. The search area is defined as the lines between the start and target nodes, plus a number of lines above and below. The number of extra lines is based on the length of the movement - moving further means more surrounding lines will be considered.

By preventing Dijkstra's algorithm from exploring outside of this area, performance is significantly improved, although sometimes a better path is sacrificed. However, that better path would most often not be obvious to a human without first scrolling the window up and down to see the surrounding lines. The better speed is most noticeable when making complicated horizontal movements on a single line.

- [x] Limit search area
- [x] Make the bounds configurable
- [x] Make this feature able to be disabled
- [x] Docs

Fixes #7